### PR TITLE
Allow more than 9 docker images

### DIFF
--- a/lib/gulp_docker/docker.coffee
+++ b/lib/gulp_docker/docker.coffee
@@ -46,7 +46,7 @@ module.exports = (GulpDocker) ->
             if input == ""
               containers
             else
-              input.match(/\d/g).map (index) ->
+              input.match(/\d+/g).map (index) ->
                 containers[parseInt(index) - 1]
         )
 


### PR DESCRIPTION
Hi, great plugin - we've been using it extensively but have come across a small issue:

If you have 10 or more image definitions, selecting the 10th one from the list looks like it selects the first image, and in my case results in the following crash:

```
[15:35:14] 'docker:image' errored after 3.6 s
[15:35:14] TypeError: Cannot set property 'push' of undefined
  at /home/spineii-user/npfs/infrastructure/docker/node_modules/gulp-docker/lib/gulp_docker/docker.coffee:74:15
  at tryCatcher (/home/spineii-user/npfs/infrastructure/docker/node_modules/gulp-docker/node_modules/bluebird/js/main/util.js:24:31)
  at Promise._settlePromiseFromHandler (/home/spineii-user/npfs/infrastructure/docker/node_modules/gulp-docker/node_modules/bluebird/js/main/promise.js:454:31)
  at Promise._settlePromiseAt (/home/spineii-user/npfs/infrastructure/docker/node_modules/gulp-docker/node_modules/bluebird/js/main/promise.js:530:18)
  at Promise._settlePromises (/home/spineii-user/npfs/infrastructure/docker/node_modules/gulp-docker/node_modules/bluebird/js/main/promise.js:646:14)
  at Async._drainQueue (/home/spineii-user/npfs/infrastructure/docker/node_modules/gulp-docker/node_modules/bluebird/js/main/async.js:177:16)
  at Async._drainQueues (/home/spineii-user/npfs/infrastructure/docker/node_modules/gulp-docker/node_modules/bluebird/js/main/async.js:187:10)
  at Immediate.Async.drainQueues [as _onImmediate] (/home/spineii-user/npfs/infrastructure/docker/node_modules/gulp-docker/node_modules/bluebird/js/main/async.js:15:14)
  at processImmediate [as _immediateCallback] (timers.js:358:17)
```

I've tracked it down to the input matching only a single digit, whereas it should accept any number of digits. The change is minimal and I can verify it fixes the crash, and builds the 10th image properly.

If you're happy to merge this, could you also publish a new version to npm please?
