### PR TITLE
Fixes setting push option based on environmental variable

### DIFF
--- a/lib/gulp_docker/docker.coffee
+++ b/lib/gulp_docker/docker.coffee
@@ -62,7 +62,7 @@ module.exports = (GulpDocker) ->
 
       if push
         for container in containers
-          container.push = push
+          container.push = (push === 'true')
 
         Promise.resolve(containers)
       else


### PR DESCRIPTION
Previously no matter what value the user put into `PUSH` env variable, it always made push, because non-empty string is always truthy. After this commit, it will run push only if `PUSH` variable is set to `true`.
