### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ Each value of the object is another object with the following possible keys:
 * Generate run arguments from container options.
 * Call `docker run` with arguments.
 
+## How to avoid user prompts
+
+Simply set the following two environment variables:
+* IMAGE - string, the name of the image to build
+* PUSH - int, enter '1' for auto push
+
 ## Dev setup
 
 	npm install

--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ Simply set the following two environment variables:
 * IMAGE - string, the name of the image to build
 * PUSH - int, enter '1' for auto push
 
+You can set these in your Gulp task like so:
+```
+process.env.IMAGE = 'Image name here';
+process.env.PUSH = 1;
+```
+or whereever you set your other environment variables.
+
 ## Dev setup
 
 	npm install


### PR DESCRIPTION
After several hours trying to work around the user prompts in my CI environment, I dug in the code and found that if you set these environment variables, you can avoid the prompts. This should be very obvious to users in the documentation and not hidden in the code.